### PR TITLE
Clean training logic

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -119,8 +119,7 @@ TRAIN_DEFAULTS.update({
     'interval_validate': 500,  # number of episodes between model validation runs
     'vcf_panel': None,
     'panel_validation': None,  # fragment files for validation
-    'panel_validation_vcfs': None,  # VCF files for validation
-    'validate': True,
+    'vcf_panel_validation': None,  # VCF files for validation
     'render_view': "weighted_view",
     'load_components': True,
     'store_components': True,

--- a/engine/config.py
+++ b/engine/config.py
@@ -226,7 +226,6 @@ class DataConfig(Config):
             'shuffle': True,
             'seed': 1234,  # Random seed
             'num_samples_per_category_default': 1000,
-            'drop_redundant': False,
             'global_ranges': {},
             'ordering_ranges': {},
         }
@@ -237,7 +236,7 @@ class DataConfig(Config):
 
 def load_config(fname, config_type=CONFIG_TYPE.TRAIN):
     # Load a YAML configuration file
-    if not os.path.exists(fname): return None
+    if fname is None: return None
     with open(fname) as file:
         config = yaml.load(file, Loader=yaml.FullLoader)
     if config_type == CONFIG_TYPE.TRAIN:

--- a/engine/config.py
+++ b/engine/config.py
@@ -197,9 +197,6 @@ class TrainingConfig(Config):
             wandb.init(project=self.project_name, entity="ralphi", dir=self.log_dir, mode="disabled")
 
         # logging
-        logging.basicConfig(format='[%(levelname)s] %(message)s', level=logging.INFO,
-                            handlers=[logging.FileHandler(self.log_dir + '/training.log', mode='w'),
-                                      logging.StreamHandler(sys.stdout)])
         logging.info(self)
 
         # enforce light logging if using multithreading validation

--- a/engine/config.py
+++ b/engine/config.py
@@ -72,7 +72,7 @@ DATA_DEFAULTS_SHORT = {
     'max_isize': 1000,
     'max_discordance': 1.0,
     'skip_post': False,
-    'read_overlap_th': None
+    'read_overlap_th': None,
 }
 
 
@@ -166,7 +166,6 @@ class PhaseConfig(Config):
         else:
             self.set_defaults(DATA_DEFAULTS_LONG)
         self.set_defaults(PHASE_DEFAULTS)
-        self.__dict__.update(entries)
         super().__init__(config_file)
 
         self.device = torch.device("cpu")
@@ -182,7 +181,6 @@ class TrainingConfig(Config):
         else:
             self.set_defaults(DATA_DEFAULTS_LONG)
         self.set_defaults(TRAIN_DEFAULTS)
-
         super().__init__(config_file)
         self.model_path = self.out_dir + "/ralphi_model_final.pt"
         self.best_model_path = self.out_dir + "/ralphi_model_best.pt"

--- a/engine/phase.py
+++ b/engine/phase.py
@@ -32,7 +32,7 @@ def phase(chr_names, config):  # runs phasing on the specified list of chromosom
         # -------- run ralphi on all the connected components of the fragment graph
         while env.has_state():
             if env.state.frag_graph.trivial: env.process_error_free_instance()
-            else: agent.run_episode(config, test_mode=True)
+            else: agent.run_episode(test_mode=True)
             env.reset()
         env.postprocess()
 

--- a/engine/phase.py
+++ b/engine/phase.py
@@ -11,9 +11,7 @@ from seq.frags import generate_fragments
 import logging
 import numpy as np
 from joblib import Parallel, delayed
-import pickle
 import random
-import tqdm
 
 print("***********************************************")
 print("*  ralphi (%s): haplotype assembly mode *" % engine.__version__)

--- a/engine/preprocess.py
+++ b/engine/preprocess.py
@@ -1,4 +1,6 @@
 import argparse
+import logging
+
 import graphs.frag_graph
 import random
 import engine.config as config_utils
@@ -20,10 +22,14 @@ if __name__ == '__main__':
     random.seed(config.seed)
     graph_dataset = graphs.frag_graph.GraphDataset(config)
     global_df = graph_dataset.load_indices()
+    logging.info('Overall the dataset contains %d graphs' % global_df.shape[0])
     if validation_config is not None:
         validation_df = graphs.frag_graph.GraphDataset(config, validation_config).load_indices()
+        logging.info('Validation dataset number of graphs %d' % validation_df.shape[0])
         # Remove the validation graphs from the pool of graphs available for training
         global_df = global_df[~global_df.component_path.isin(validation_df.component_path)]
+        logging.info('Remaining %d graphs available for training' % global_df.shape[0])
 
     if training_config is not None:
         training_dataset = graph_dataset.dataset_nested_design(global_df, training_config)
+        logging.info('Training dataset number of graphs %d' % training_dataset.shape[0])

--- a/engine/preprocess.py
+++ b/engine/preprocess.py
@@ -9,15 +9,15 @@ if __name__ == '__main__':
     # ------ CLI ------
     parser = argparse.ArgumentParser(description='Train haplotype phasing')
     parser.add_argument('--config', help='Training configuration YAML')
-    parser.add_argument('--training_ordering_config', help='Training configuration YAML')
-    parser.add_argument('--validation_ordering_config', help='Training configuration YAML')
+    parser.add_argument('--training_config', help='Training configuration YAML')
+    parser.add_argument('--validation_config', help='Training configuration YAML')
     args = parser.parse_args()
     # -----------------
 
     # Load the config
     config = config_utils.load_config(args.config)
-    training_config = config_utils.load_config(args.training_ordering_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
-    validation_config = config_utils.load_config(args.validation_ordering_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
+    training_config = config_utils.load_config(args.training_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
+    validation_config = config_utils.load_config(args.validation_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
 
     random.seed(config.seed)
     graph_dataset = graphs.frag_graph.GraphDataset(config)

--- a/engine/preprocess.py
+++ b/engine/preprocess.py
@@ -1,0 +1,29 @@
+import argparse
+import graphs.frag_graph
+import random
+import engine.config as config_utils
+
+if __name__ == '__main__':
+    # ------ CLI ------
+    parser = argparse.ArgumentParser(description='Train haplotype phasing')
+    parser.add_argument('--config', help='Training configuration YAML')
+    parser.add_argument('--training_ordering_config', help='Training configuration YAML')
+    parser.add_argument('--validation_ordering_config', help='Training configuration YAML')
+    args = parser.parse_args()
+    # -----------------
+
+    # Load the config
+    config = config_utils.load_config(args.config)
+    training_config = config_utils.load_config(args.training_ordering_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
+    validation_config = config_utils.load_config(args.validation_ordering_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
+
+    random.seed(config.seed)
+    graph_dataset = graphs.frag_graph.GraphDataset(config)
+    global_df = graph_dataset.load_indices()
+    if validation_config is not None:
+        validation_df = graphs.frag_graph.GraphDataset(config, validation_config).load_indices()
+        # Remove the validation graphs from the pool of graphs available for training
+        global_df = global_df[~global_df.component_path.isin(validation_df.component_path)]
+
+    if training_config is not None:
+        training_dataset = graph_dataset.dataset_nested_design(global_df, training_config)

--- a/engine/train.py
+++ b/engine/train.py
@@ -7,33 +7,37 @@ import random
 import engine.config as config_utils
 import engine.validate
 import dgl
+import os
 
 
 if __name__ == '__main__':
     # ------ CLI ------
     parser = argparse.ArgumentParser(description='Train haplotype phasing')
     parser.add_argument('--config', help='Training configuration YAML')
-    parser.add_argument('--training_dataset_config', help='Config to specify training data design')
-    parser.add_argument('--validation_dataset_config', help='Config to specify validation data design')
     args = parser.parse_args()
     # -----------------
+    training_ordering_path = args.config.split('.yaml')[0] + 'training_ordering.yaml'
+    validation_ordering_path = args.config.split('.yaml')[0] + 'validation_ordering.yaml'
 
     # Load the config
     config = config_utils.load_config(args.config)
-    training_config = config_utils.load_config(args.training_dataset_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
-    validation_config = config_utils.load_config(args.validation_dataset_config, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
+    training_config = config_utils.load_config(training_ordering_path, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
+    validation_config = config_utils.load_config(validation_ordering_path, config_type=config_utils.CONFIG_TYPE.DATA_DESIGN)
 
     torch.manual_seed(config.seed)
     random.seed(config.seed)
     dgl.seed(config.seed)
     torch.set_default_tensor_type(torch.DoubleTensor)
     torch.set_num_threads(config.num_cores_torch)
-    training_dataset = graphs.frag_graph.GraphDataset(config, training_config, validation_mode=False).load_indices()
+    graph_dataset = graphs.frag_graph.GraphDataset(config, training_config, validation_mode=False)
+    training_dataset = graph_dataset.load_indices()
 
-    if config.panel_validation_frags and config.panel_validation_vcfs:
-        validation_dataset = graphs.frag_graph.GraphDataset(config, validation_config, validation_mode=True).load_indices()
-        # e.g. to only validate on cases with articulation points
-        # validation_dataset = validation_dataset[validation_dataset["articulation_points"] != 0]
+    if config.validate:
+        if config.panel_validation_frags and config.panel_validation_vcfs:
+            validation_dataset = graphs.frag_graph.GraphDataset(config, validation_config, validation_mode=True).load_indices()
+        else:
+            validation_dataset = graph_dataset.make_validation(validation_config)
+
 
     # Setup the agent and the training environment
     env_train = envs.PhasingEnv(config, graph_dataset=training_dataset)

--- a/engine/train.py
+++ b/engine/train.py
@@ -27,20 +27,16 @@ if __name__ == '__main__':
     torch.set_num_threads(config.num_cores_torch)
     graph_dataset = graphs.frag_graph.GraphDataset(config, validation_mode=False)
     training_dataset = graph_dataset.load_indices()
-
     if config.panel_validation:
         validation_dataset = graphs.frag_graph.GraphDataset(config, validation_mode=True).load_indices()
-
 
     # Setup the agent and the training environment
     env_train = envs.PhasingEnv(config, graph_dataset=training_dataset)
     agent = agents.DiscreteActorCriticAgent(env_train)
-
     if config.pretrained_model is not None:
         agent.model.load_state_dict(torch.load(config.pretrained_model))
-
     # Run the training
-    best_validation_reward = None
+    best_validation_reward = 0
     best_validation_reward_id = 0
     model_checkpoint_id = 0
     episode_id = 0
@@ -56,7 +52,7 @@ if __name__ == '__main__':
             if config.panel_validation:
                 reward = engine.validate.validate(model_checkpoint_id, episode_id, validation_dataset, config)
                 model_checkpoint_id += 1
-                if best_validation_reward is None or reward > best_validation_reward:
+                if reward > best_validation_reward:
                     best_validation_reward = reward
                     best_validation_reward_id = model_checkpoint_id
                     torch.save(agent.model.state_dict(), config.best_model_path)

--- a/engine/train.py
+++ b/engine/train.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
 
     while agent.env.has_state():
         if not (config.min_graph_size <= agent.env.state.num_nodes <= config.max_graph_size):
+            agent.env.reset()
             continue
         if config.max_episodes is not None and episode_id >= config.max_episodes:
             break

--- a/engine/validate.py
+++ b/engine/validate.py
@@ -1,149 +1,61 @@
-import third_party.HapCUT2.utilities.calculate_haplotype_statistics as benchmark
-import utils.hap_block_visualizer as hap_block_visualizer
-import pickle
-import utils.post_processing
-import seq.phased_vcf as vcf_writer
+from copy import deepcopy
+from operator import index
+
 import pandas as pd
-import engine.config as config_utils
 import wandb
 import logging
-import seq.var as var
-import tqdm
 import envs.phasing_env as envs
-import os
 import models.actor_critic as agents
 import torch
 from joblib import Parallel, delayed
 
-
-def compute_error_rates(solutions, validation_input_vcf, agent, config, genome, group):
-    # given any subset of phasing solutions, computes errors rates against ground truth VCF
-
-    idx2var = var.extract_variants(solutions)
-    for v in idx2var.values():
-        v.assign_haplotype()
-
-    output_vcf = config.validation_output_vcf + "_" + str(group) + ".vcf"
-    vcf_writer.write_phased_vcf(validation_input_vcf, idx2var, output_vcf)
-    chrom = benchmark.get_ref_name(output_vcf)
-    benchmark_result = benchmark.vcf_vcf_error_rate(output_vcf, validation_input_vcf, indels=False)
-    if not config.light_logging:
-        hap_blocks = hap_block_visualizer.pretty_print(solutions, idx2var.items(), validation_input_vcf, genome)
-        return chrom, benchmark_result, hap_blocks
-    else:
-        return chrom, benchmark_result, None
-
-def log_error_rates(solutions, input_vcf, sum_of_cuts, sum_of_rewards, model_checkpoint_id, episode_id, agent, config, genome, group, descriptor="_default_"):
-    chrom, benchmark_result, hap_blocks = compute_error_rates(solutions, input_vcf, agent, config, genome, group)
-    if not config.light_logging:
-        AN50 = benchmark_result.get_AN50()
-        N50 = benchmark_result.get_N50_phased_portion()
-        label = descriptor + ", " + chrom
-
-        with open(config.out_dir + "/benchmark_" + str(group) + ".txt", "a") as out_file:
-            out_file.write("benchmark of model: " + str(model_checkpoint_id) + "\n")
-            out_file.write("switch count: " + str(benchmark_result.switch_count[chrom]) + "\n")
-            out_file.write("mismatch count: " + str(benchmark_result.mismatch_count[chrom]) + "\n")
-            out_file.write("switch loc: " + str(benchmark_result.switch_loc[chrom]) + "\n")
-            out_file.write("mismatch loc: " + str(benchmark_result.mismatch_loc[chrom]) + "\n")
-            out_file.write("flat count: " + str(benchmark_result.flat_count[chrom]) + "\n")
-            out_file.write("phased count: " + str(benchmark_result.phased_count[chrom]) + "\n")
-            out_file.write("AN50: " + str(AN50) + "\n")
-            out_file.write("N50: " + str(N50) + "\n")
-            out_file.write("sum of cuts: " + str(sum_of_cuts) + "\n")
-            out_file.write(descriptor + "\n")
-            out_file.write(str(benchmark_result) + "\n")
-            if benchmark_result.switch_count[chrom] > 0 or benchmark_result.mismatch_count[chrom] > 0:
-                out_file.write(str(hap_blocks) + "\n")
-
-        logging.getLogger(config_utils.STATS_LOG_VALIDATE).info("%s,%s,%s,%s, %s,%s,%s,%s,%s,%s"
-                                                                % (label, episode_id, sum_of_cuts, sum_of_rewards,
-                                                                   benchmark_result.switch_count[chrom],
-                                                                   benchmark_result.mismatch_count[chrom],
-                                                                   benchmark_result.flat_count[chrom],
-                                                                   benchmark_result.phased_count[chrom], AN50, N50))
-    # output the phased VCF (phase blocks)
-    return chrom, benchmark_result.switch_count[chrom], benchmark_result.mismatch_count[chrom], benchmark_result.flat_count[chrom], benchmark_result.phased_count[chrom]
-
-
-def validation_task(input_tuple):
-    model_checkpoint_id, episode_id, sub_df, model_path, config, group = input_tuple
-    torch.set_num_threads(config.num_cores_torch)
+def validation_task(sub_df, config, model_path):
+    config = deepcopy(config)
+    config.epochs = 1
+    logging.root.setLevel(logging.getLevelName(config.logging_level))
     task_component_stats = []
-    agent = None
-    for index, component_row in tqdm.tqdm(sub_df.iterrows()):
-        with open(component_row.component_path, 'rb') as f:
-            subgraph = pickle.load(f)
-            subgraph.indexed_graph_stats = component_row
-            mini_env = envs.PhasingEnv(config, preloaded_graphs=subgraph, record_solutions= not config.ultra_light_mode)
-            if agent is not None:
-                agent.env = mini_env
-            else:
-                agent = agents.DiscreteActorCriticAgent(mini_env)
-                agent.model.load_state_dict(torch.load(model_path))
-            sum_of_rewards = 0
-            sum_of_cuts = 0
-            reward_val = agent.run_episode(config, test_mode=True)
-            sum_of_rewards += reward_val
-            cut_val = agent.env.get_cut_value()
-            sum_of_cuts += cut_val
-            if config.debug:
-                graph_stats = agent.env.state.frag_graph.graph_properties
-
-                graph_path = os.path.split(component_row.component_path)[1] + str(graph_stats)
-                graph_stats["cut_value"] = cut_val
-
-                if not config.light_logging:
-                    wandb.log({"Episode": episode_id,
-                               "Cut Value on: " + str(component_row.genome) + "_" + str(component_row.coverage) + "_" + str(
-                                   component_row.error_rate) + "_" + graph_path: graph_stats["cut_value"]})
-
-                ch = 0
-                sw = 0
-                mis = 0
-                flat = 0
-                phased = 0
-                if not config.ultra_light_mode:
-                    vcf_path = component_row.component_path + ".vcf"
-
-                    ch, sw, mis, flat, phased = log_error_rates([agent.env.state.frag_graph.fragments], vcf_path,
-                                                            cut_val, reward_val, model_checkpoint_id, episode_id, agent,
-                                                            config, component_row.genome, group, graph_path)
-
-                cur_index = component_row.values.tolist()
-                cur_index.extend([sw, mis, flat, phased, reward_val, cut_val, ch])
-
-                task_component_stats.append(cur_index)
-                    
-    return pd.DataFrame(task_component_stats, columns=list(sub_df.columns) + ["switch", "mismatch", "flat", "phased", "reward_val", "cut_val", "chr"])
+    validate_env = envs.PhasingEnv(config, record_solutions=not config.debug, graph_dataset=sub_df)
+    agent = agents.DiscreteActorCriticAgent(validate_env)
+    agent.model.load_state_dict(torch.load(model_path))
+    index_validate = 0
+    while agent.env.has_state():
+        sum_of_rewards = 0
+        sum_of_cuts = 0
+        reward_val = agent.run_episode(test_mode=True)
+        sum_of_rewards += reward_val
+        cut_val = agent.env.get_cut_value()
+        sum_of_cuts += cut_val
+        if config.debug:
+            cur_index = sub_df.iloc[index_validate, :].values.tolist()
+            cur_index.extend([reward_val, cut_val])
+            task_component_stats.append(cur_index)
+        index_validate += 1
+        if index_validate % 100 == 0:
+            logging.info('Validation graph %d' % index_validate)
+        agent.env.reset()
+    return pd.DataFrame(task_component_stats, columns=list(sub_df.columns) + ["reward_val", "cut_val"])
 
 def validate(model_checkpoint_id, episode_id, validation_dataset, config):
     # benchmark the current model against a held out set of fragment graphs (validation panel)
-
-    print("running validation with model number:  ", model_checkpoint_id, ", at episode: ", episode_id)
-
-    input_tuples = []
-    for i, sub_df in enumerate(validation_dataset):
-        input_tuples.append((model_checkpoint_id, episode_id, sub_df, "%s/dphase_model_%d.pt" % (config.out_dir, model_checkpoint_id), config, str(i)))
-    validation_component_stats = Parallel(n_jobs=config.num_cores_validation)(delayed(validation_task)(input_elem) for input_elem in input_tuples)
+    logging.info("running validation with model number: %d, at episode: %d" % (model_checkpoint_id, episode_id))
+    model_path = "%s/ralphi_model_%d.pt" % (config.out_dir, model_checkpoint_id)
+    validation_component_stats = Parallel(n_jobs=config.n_procs)(delayed(validation_task)(sub_df, config,
+                                                                    model_path) for sub_df in validation_dataset)
 
     validation_indexing_df = pd.concat(validation_component_stats)
     validation_indexing_df.to_pickle("%s/validation_index_for_model_%d.pickle" % (config.out_dir, model_checkpoint_id))
-    def log_stats_for_filter(validation_filtered_df, descriptor="Overall"):
-        metrics_of_interest = ["reward_val", "cut_val", "switch", "mismatch", "flat", "phased"]
-        for metric in metrics_of_interest:
-            wandb.log({"Episode": episode_id, descriptor + " Validation " + metric + " on " + "_default_overall": validation_filtered_df[metric].sum()})
-        wandb.log({"Episode": episode_id, descriptor + " Validation " + "Number of Examples" + " on " + "_default_overall": len(validation_filtered_df)})
-        percentage_metrics = ["switch", "mismatch", "flat"]
-        for metric in percentage_metrics:
-            wandb.log({"Episode": episode_id, descriptor + " Validation " + "% with " + metric + " errors" + " on " + "_default_overall": len(validation_filtered_df[validation_filtered_df[metric] > 0]) / len(validation_filtered_df)})
+    def log_stats_for_filter(validation_filtered_df):
+        metrics_of_interest = ["reward_val", "cut_val"]
+        def log_wandb(df, group):
+            for metric in metrics_of_interest:
+                wandb.log({"Episode": episode_id, "Validation_" + metric + "_" + group: df[metric].sum()})
+            wandb.log({"Episode": episode_id, "Validation_number_examples_" + group: len(df)})
+        log_wandb(validation_filtered_df, "overall")
+        groups = validation_filtered_df['group'].unique()
+        for group in groups:
+            df_group = validation_filtered_df[validation_filtered_df['group'] == group]
+            log_wandb(df_group, group)
 
     # stats for entire validation set
     log_stats_for_filter(validation_indexing_df)
-
-    # log stats for graphs from each quantile of each graph property specified in the validation config
-    keys = validation_indexing_df.group.unique()
-    for group in validation_indexing_df.group.unique():
-        log_stats_for_filter(validation_indexing_df[validation_indexing_df["group"] == group], "group: " + str(group))
-
     return validation_indexing_df["reward_val"].sum()

--- a/engine/validate.py
+++ b/engine/validate.py
@@ -1,6 +1,4 @@
 from copy import deepcopy
-from operator import index
-
 import pandas as pd
 import wandb
 import logging

--- a/envs/phasing_env.py
+++ b/envs/phasing_env.py
@@ -50,7 +50,6 @@ class PhasingEnv(gym.Env):
     def init_state(self):
         g = next(self.graph_gen)
         if g is not None:
-            g.normalize_edges(self.config.weight_norm, self.config.fragment_norm)
             return State(g, self.features, self.config.device)
         else:
             return None
@@ -84,9 +83,6 @@ class PhasingEnv(gym.Env):
         else:
             return max((self.state.current_total_reward - self.state.best_reward) /
                        self.state.frag_graph.graph_properties["total_num_frag"], 0)
-
-    def is_termination_action(self, action):
-        return action == self.state.num_nodes
 
     def is_out_of_moves(self):
         return len(self.state.H0) + len(self.state.H1) >= self.state.num_nodes
@@ -170,12 +166,6 @@ class PhasingEnv(gym.Env):
             edge_indices = zip(edges_src, edges_dst)
             edge_weights = dict(zip(edge_indices, edge_weights))
             vis.plot_weighted_network(self.state.g.to_networkx(), node_labels, edge_weights)
-
-    def get_all_valid_actions(self):
-        return (self.state.assigned == 0.).nonzero()
-
-    def get_all_non_neighbour_actions(self):
-        return (self.state.explorable == 0.).nonzero()
 
     def get_all_invalid_actions(self):
         return (self.state.assigned == 1.).nonzero()

--- a/envs/phasing_env.py
+++ b/envs/phasing_env.py
@@ -23,7 +23,6 @@ class State:
         self.g = dgl.from_networkx(frag_graph.g.to_directed(), edge_attrs=edge_attrs, node_attrs=features)
         self.g = self.g.to(device) 
         self.assigned = torch.zeros(self.num_nodes * 2)
-        self.explorable = torch.zeros(self.num_nodes * 2)
         self.H0 = []
         self.H1 = []
         self.best_reward = 0
@@ -39,10 +38,6 @@ class PhasingEnv(gym.Env):
         self.state = self.init_state()
         if not self.has_state():
             raise ValueError("Environment state was not initialized: no valid input graphs")
-        # action space consists of the set of nodes we can assign and a termination step
-        self.num_actions = self.state.num_nodes * 2
-        self.action_space = spaces.Discrete(self.num_actions)
-        self.observation_space = {}
         # other bookkeeping
         self.record = record_solutions
         self.solutions = []

--- a/envs/phasing_env.py
+++ b/envs/phasing_env.py
@@ -145,12 +145,6 @@ class PhasingEnv(gym.Env):
             else: raise RuntimeError("Fragment wasn't assigned to any cluster")
         self.solutions.append(self.state.frag_graph.fragments)
 
-    def get_solutions(self):
-        node_labels = self.state.g.ndata['cut_member_hap0'][:, 0].cpu().numpy().tolist()
-        for i, frag in enumerate(self.state.frag_graph.fragments):
-            frag.assign_haplotype(node_labels[i])
-        return self.state.frag_graph.fragments
-
     def get_cut_value(self):
         return self.state.current_total_reward
 

--- a/graphs/frag_graph.py
+++ b/graphs/frag_graph.py
@@ -297,10 +297,10 @@ class GraphDataset:
             self.panel = config.panel_validation
             self.vcf_panel = config.vcf_panel_validation
         if ordering_config:
-            selection_features = [constants.FEATURES_DICT[feature] for group in ordering_config.ordering_ranges for feature in
-                                  ordering_config.ordering_ranges[group]["rules"] if constants.FEATURES_DICT[feature] not in self.features + ['n_nodes']]
-            selection_features += [constants.FEATURES_DICT[feature] for feature in ordering_config.global_ranges if constants.FEATURES_DICT[feature] not in
-                                                                                            self.features + ['n_nodes']]
+            selection_features = [feature for group in ordering_config.ordering_ranges for feature_name in
+                                  ordering_config.ordering_ranges[group]["rules"] for feature in constants.FEATURES_DICT[feature_name] if feature not in self.features + ['n_nodes']]
+            selection_features += [feature for feature_name in ordering_config.global_ranges for feature in
+                                   constants.FEATURES_DICT[feature_name] if feature not in self.features + ['n_nodes']]
             selection_features = list(set(selection_features))
             if selection_features:
                 self.features += selection_features

--- a/graphs/frag_graph.py
+++ b/graphs/frag_graph.py
@@ -295,11 +295,11 @@ class GraphDataset:
             self.vcf_panel = config.vcf_panel
         else:
             self.panel = config.panel_validation
-            self.vcf_panel = config.panel_validation_vcfs
+            self.vcf_panel = config.vcf_panel_validation
         if ordering_config:
-            selection_features = [feature for group in ordering_config.ordering_ranges for feature in
-                                  ordering_config.ordering_ranges[group]["rules"] if feature not in self.features + ['n_nodes']]
-            selection_features += [feature for feature in ordering_config.global_ranges if feature not in
+            selection_features = [constants.FEATURES_DICT[feature] for group in ordering_config.ordering_ranges for feature in
+                                  ordering_config.ordering_ranges[group]["rules"] if constants.FEATURES_DICT[feature] not in self.features + ['n_nodes']]
+            selection_features += [constants.FEATURES_DICT[feature] for feature in ordering_config.global_ranges if constants.FEATURES_DICT[feature] not in
                                                                                             self.features + ['n_nodes']]
             selection_features = list(set(selection_features))
             if selection_features:

--- a/graphs/frag_graph.py
+++ b/graphs/frag_graph.py
@@ -384,9 +384,10 @@ class GraphDataset:
             panels = open(self.panel, 'r').readlines()
             datasets = []
             for panel in panels:
-                path_panel = panel.strip() + ".index_per_graph"
-                datasets.append(pd.read_pickle(path_panel))
+                path_sub_panel = panel.strip() + ".index_per_graph"
+                datasets.append(pd.read_pickle(path_sub_panel))
             graph_dataset = pd.concat(datasets)
+            graph_dataset.to_pickle(path_panel)
         logging.info("graph dataset... %s" % graph_dataset.describe())
 
         if self.ordering_config is not None:

--- a/models/actor_critic.py
+++ b/models/actor_critic.py
@@ -4,9 +4,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions.categorical import Categorical
 from models.graph_models import GIN, GCN, GCNv2
-import time
-import logging
-import engine.config as config
 import models.constants as constants
 import wandb
 from torch.nn.utils import spectral_norm
@@ -66,13 +63,11 @@ class DiscreteActorCriticAgent:
                 if isinstance(v, torch.Tensor):
                     state[k] = v.to(self.env.config.device)
 
-    def run_episode(self, config, test_mode=False, episode_id=None):
+    def run_episode(self, test_mode=False, episode_id=None):
         done = False
         episode_reward = 0
-        first = True
         while not done:
-            action = self.select_action(test_mode, first=first)
-            first = False
+            action = self.select_action(test_mode)
             _, reward, done = self.env.step(action)
             episode_reward += reward
             if not test_mode: self.model.rewards.append(reward)
@@ -83,24 +78,7 @@ class DiscreteActorCriticAgent:
             wandb.log({"Episode": episode_id, "Training Cut Size": cut_size})
         return episode_reward
 
-    def log_episode_stats(self, episode_id, reward, loss, runtime):
-        self.env.state.frag_graph.log_graph_properties(episode_id)
-        graph_stats = []
-        logging.getLogger(config.MAIN_LOG).info("Episode: %d. Reward: %d, ActorLoss: %d, CriticLoss: %d, TotalLoss: %d,"
-                                                " CutSize: %d, Runtime: %d" %
-                                                (episode_id, reward,
-                                                 loss[constants.LossTypes.actor_loss],
-                                                 loss[constants.LossTypes.critic_loss],
-                                                 loss[constants.LossTypes.total_loss],
-                                                 self.env.get_cut_value(),
-                                                 runtime))
-        logging.getLogger(config.STATS_LOG_TRAIN).info(",".join([str(episode_id), str(reward),
-                                                                 str(self.env.get_cut_value()),
-                                                                 str(loss),
-                                                                 str(graph_stats),
-                                                                 str(runtime)]))
-
-    def select_action(self, greedy=False, first=False):
+    def select_action(self, greedy=False):
         # based on DAC model in:
         # https://github.com/orrivlin/MinimumVertexCover_DRL/blob/master/discrete_actor_critic.py
         if self.env.state.num_nodes < 2:

--- a/models/constants.py
+++ b/models/constants.py
@@ -14,5 +14,33 @@ FEATURES_DICT = {
     ],
     'between': [
         'betweenness'
+    ],
+
+    'min_weight': [
+        'min_weight'
+    ],
+    'max_weight': [
+        'max_weight'
+    ],
+    'n_edges': [
+        'n_edges'
+    ],
+    'n_nodes': [
+        'n_nodes'
+    ],
+    'density': [
+        'density'
+    ],
+    'diameter': [
+        'diameter'
+    ],
+    'n_variants': [
+        'n_variants'
+    ],
+    'compression_factor': [
+        'compression_factor'
+    ],
+    'articulation_points': [
+        'articulation_points'
     ]
 }

--- a/models/constants.py
+++ b/models/constants.py
@@ -40,7 +40,7 @@ FEATURES_DICT = {
     'compression_factor': [
         'compression_factor'
     ],
-    'articulation_points': [
+    'n_articulation_points': [
         'articulation_points'
     ]
 }

--- a/models/graph_models.py
+++ b/models/graph_models.py
@@ -1,4 +1,3 @@
-import torch as th
 import torch.nn as nn
 import dgl
 import inspect

--- a/seq/frags.py
+++ b/seq/frags.py
@@ -1,5 +1,4 @@
-import argparse
-from collections import Counter, defaultdict
+from collections import defaultdict
 from copy import deepcopy
 from intervaltree import IntervalTree
 import logging
@@ -7,7 +6,6 @@ import whatshap
 import string
 from whatshap import readselect
 from whatshap.cli import PhasedInputReader
-from whatshap import merge
 
 class FragVariantHandle:
     def __init__(self, vcf_idx, allele, qscore=None):

--- a/seq/utils.py
+++ b/seq/utils.py
@@ -38,14 +38,6 @@ def filter_vcf(vcf_fname, filters):
         if keep:
             writer.write_record(record)
 
-def construct_vcf_idx_to_record_dict(input_vcf):
-    vcf_reader = vcf.Reader(open(input_vcf, 'r'), strict_whitespace=True)
-    assert (len(vcf_reader.samples) == 1), "Only single-sample files are expected"
-    row_to_record_dict = {}
-    for vcf_idx, record in enumerate(vcf_reader):
-        row_to_record_dict[vcf_idx] = record
-    return row_to_record_dict
-
 def extract_vcf_for_variants(vcf_positions, input_vcf, output_vcf, vcf_dict):
     vcf_reader = vcf.Reader(open(input_vcf, 'r'), strict_whitespace=True)
     assert (len(vcf_reader.samples) == 1), "Only single-sample files are expected"


### PR DESCRIPTION
Create a preprocess.py to use to create training and validation datasets of precomputed graphs that can be filtered or ordered using dedicated YAML files.
Remove obsolete training-related code.
The code in train.py can either use a precomputed dataset or BAM files directly. In the latter case, all the graphs will be used in a random order.
Update the readme with the training and preprocessing description.